### PR TITLE
Added comment support to the website

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -54,6 +54,15 @@
     </section>
 </article>
 
+<script src="https://utteranc.es/client.js"
+        repo="VeckoTheGecko/vecko.me"
+        issue-term="pathname"
+        label="💬comments "
+        theme="dark-blue"
+        crossorigin="anonymous"
+        async>
+</script>
+
 <script src='{{"js/progress-bar.js" | absURL}}'></script>
 
 {{end}}


### PR DESCRIPTION
Used [utteranc.es](utteranc.es) to add commen support to the website on a post by post basis.

Closes #4 